### PR TITLE
Add node_id component with thread-safe initialization and custom iden…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# examples
+**/examples/**/sdkconfig
+**/examples/**/sdkconfig.old
+**/examples/**/build
+
+# ESP-IDF default build directory name
+build
+sdkconfig
+sdkconfig.old
+
+# lock files for examples and components
+dependencies.lock
+
+# managed_components for examples
+managed_components
+
+# pytest log
+pytest_embedded_log/
+
+# vscode
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [0.2.0] - 2025-09-02
+### Added
+- Thread-safe initialization of node ID using FreeRTOS mutex.
+- Support for custom identity (e.g., public key) as input to node_id_init.
+- `node_id_force_init` API for forced re-initialization (unsafe, see docs).
+
+### Changed
+- Documentation updated to clarify thread safety and API usage.
+
+### Fixed
+- Internal buffer is never freed; always valid for process lifetime.
+
+### Warning
+- Forced re-initialization (`node_id_force_init`) is inherently unsafe if other modules are using the node ID.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "node_id.c"
     INCLUDE_DIRS "include"
-    REQUIRES esp_common esp_hw_support efuse esp_system
+    PRIV_REQUIRES mbedtls
 )

--- a/README.md
+++ b/README.md
@@ -1,21 +1,29 @@
-# node_id (ESP-IDF component)
+# esp_node_id (ESP-IDF component)
 
-Small ESP-IDF component that generates a short, human-friendly device ID from the factory MAC.
+Small ESP-IDF component that generates a short, human-friendly device ID from the factory MAC by default or a custom identiy (node public key).
 
-- Format: `XXXX-XXXC` (Crockford Base32 with 1-char checksum)
-- Stable across reboots/updates (derived from factory MAC)
-- No dynamic allocation; returns pointer to internal static buffer
-- Lightweight dependencies only (efuse + CRC)
+
+- Format: `XXXXX-XXXXX-XXX-C` (Crockford Base32 with 1-char checksum)
+- Stable across reboots/updates (derived from factory MAC by default)
+- Optionally, you can pass a custom identity (e.g., node public key) to generate a deterministic ID.
+- Thread-safe initialization (FreeRTOS mutex).
+- No dynamic allocation; returns pointer to internal static buffer (never freed).
+- Lightweight dependencies only (efuse, SHA256).
 
 ## API
 
+
 ```c
 #include "node_id.h"
+esp_err_t node_id_init(const uint8_t* identity_str, size_t len); // Thread-safe, fallback to MAC if identity_str==NULL
+esp_err_t node_id_force_init(const uint8_t* identity_str, size_t len); // Unsafe: forcibly resets node ID
 esp_err_t get_node_id(char **node_id, size_t *len);
 ```
 
-- `node_id` will point to an internal static buffer containing a null-terminated string.
+
+- `get_node_id` will point to an internal static buffer containing a null-terminated string.
 - `len` will contain the length in bytes (excluding the null terminator).
+- The buffer is never freed and remains valid for the process lifetime.
 
 ## Usage
 
@@ -29,7 +37,25 @@ size_t len = 0;
 if (get_node_id(&id, &len) == ESP_OK) {
     printf("Node ID (%d): %s\n", (int)len, id);
 }
+
+// Optionally, initialize with a custom identity (e.g., public key):
+// node_id_init(pubkey, pubkey_len);
+
+// WARNING: node_id_force_init is inherently unsafe if other modules are using the node ID.
+// It will overwrite the internal buffer and may break consumers holding a pointer.
+// Always copy the node ID string if you need to preserve it after a force init.
 ```
+
+## Unit Testing
+
+Unit tests are provided in `test/test_node_id.c` and cover:
+- Default node ID generation
+- Custom identity support
+- Robust thread safety (multiple FreeRTOS tasks)
+
+Run with ESP-IDF Unity test runner for validation.
+
+## Example
 
 A minimal example app is provided in `examples/usage/`.
 
@@ -40,20 +66,15 @@ A minimal example app is provided in `examples/usage/`.
 ## Install (from Git)
 Repo: https://github.com/swgiacomelli/esp_node_id
 
-Two simple ways:
-- Submodule: add to your project at `components/node_id`.
-- External dir: keep it anywhere and point EXTRA_COMPONENT_DIRS to its parent.
-
-Submodule example (PowerShell):
-```
-git submodule add https://github.com/swgiacomelli/esp_node_id components/node_id
-```
-
-External dir build example:
-```
-idf.py -DEXTRA_COMPONENT_DIRS="C:/path/to/esp_node_id" build
+Submodule example:
+```sh
+git submodule add https://github.com/swgiacomelli/esp_node_id components/esp_node_id
 ```
 
 ## License
 
 ISC. See `LICENSE`.
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for version history.

--- a/examples/usage/.clangd
+++ b/examples/usage/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+    Remove: [-f*, -m*]

--- a/examples/usage/CMakeLists.txt
+++ b/examples/usage/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-
-# Allow building the example as a standalone project by pointing to the parent dir as a component dir
-set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/..")
 
 project(node_id_example)

--- a/examples/usage/main/CMakeLists.txt
+++ b/examples/usage/main/CMakeLists.txt
@@ -1,1 +1,5 @@
-idf_component_register(SRCS "main.c" INCLUDE_DIRS ".")
+idf_component_register(
+    SRCS "main.c"
+    INCLUDE_DIRS "."
+    REQUIRES esp_node_id
+)

--- a/examples/usage/main/idf_component.yml
+++ b/examples/usage/main/idf_component.yml
@@ -1,0 +1,4 @@
+dependencies:
+  esp_node_id:
+    version: '0.*'
+    override_path: '../../../'

--- a/examples/usage/main/main.c
+++ b/examples/usage/main/main.c
@@ -1,16 +1,64 @@
 #include <stdio.h>
+#include <string.h>
+
+/**
+ * Example usage of the node_id ESP-IDF component.
+ *
+ * - The node ID is a short, human-friendly string derived from the device's MAC address by default.
+ * - You can optionally provide a custom identity (e.g., public key) to generate a deterministic node ID.
+ * - The API is thread-safe; the returned pointer is always to an internal static buffer (never freed).
+ * - WARNING: Forcing re-initialization (node_id_force_init) is unsafe if other modules are using the node ID.
+ *   It will overwrite the internal buffer and may break consumers holding a pointer.
+ */
+
+#include <string.h>
 #include "esp_log.h"
+#include "esp_err.h"
 #include "node_id.h"
 
 static const char *TAG = "example";
 
 void app_main(void)
 {
+    // Example custom identity (could be a public key, serial number, etc.)
+    uint8_t custom_id[] = "CUSTOM_IDENTITY";
+
     char *id = NULL;
     size_t len = 0;
+
+    // Get the default node ID (derived from MAC address)
     if (get_node_id(&id, &len) == ESP_OK)
     {
         ESP_LOGI(TAG, "Node ID (%d): %s", (int)len, id);
+
+        // Save the old node ID before force init (since get_node_id returns a pointer to a static buffer)
+        char old_id[NODE_ID_MAX_LEN];
+        strncpy(old_id, id, NODE_ID_MAX_LEN);
+        old_id[NODE_ID_MAX_LEN - 1] = '\0';
+
+        // Force re-initialization with a custom identity
+        ESP_LOGI(TAG, "Forcing custom Node ID initialization with identity: %s", custom_id);
+        ESP_LOGI(TAG, "Custom Node ID (%d): %s", (int)sizeof(custom_id), custom_id);
+
+        if (node_id_force_init(custom_id, sizeof(custom_id) - 1) == ESP_OK)
+        {
+            ESP_LOGI(TAG, "Node ID set to custom identity");
+        }
+        else
+        {
+            ESP_LOGE(TAG, "Failed to set custom node id");
+        }
+
+        // Get the new node ID after force init
+        if (get_node_id(&id, &len) == ESP_OK)
+        {
+            ESP_LOGI(TAG, "New Node ID (%d): %s", (int)len, id);
+            ESP_LOGI(TAG, "Old Node ID (%d): %s", (int)strlen(old_id), old_id);
+        }
+        else
+        {
+            ESP_LOGE(TAG, "Failed to get node id");
+        }
     }
     else
     {

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,13 +1,23 @@
-version: 0.1.0
-name: node_id
-summary: "Crockford Base32 node ID from factory MAC with checksum (format: XXXX-XXXC)."
-description: |
-  node_id provides a deterministic device identifier derived from the ESP32 factory MAC address.
-  It encodes a CRC32 of the MAC into 7 Base32 (Crockford) characters and appends a 1-character
-  checksum, yielding a compact 9-character token in the shape "XXXX-XXXC".
+version: 0.2.0
+name: esp_node_id
 
-  API:
-    - esp_err_t get_node_id(char **node_id, size_t *len);
+summary: "Thread-safe, deterministic node ID (Crockford Base32) from MAC or custom identity."
+description: |
+  esp_node_id provides a deterministic device identifier derived from the ESP32 factory MAC address by default,
+  or from a custom identity (e.g., public key) if provided. The ID is encoded in Crockford Base32 with a checksum,
+  yielding a compact, human-friendly token in the shape "XXXXX-XXXXX-XXX-C".
+
+  Features:
+    - Thread-safe initialization (FreeRTOS mutex)
+    - Fallback to MAC address if no identity is provided
+    - Optionally accept custom identity (e.g., public key)
+    - Internal static buffer is never freed; valid for process lifetime
+    - API:
+  - esp_err_t node_id_init(const uint8_t* identity_str, size_t len);
+  - esp_err_t node_id_force_init(const uint8_t* identity_str, size_t len); // Unsafe
+  - esp_err_t get_node_id(char **node_id, size_t *len);
+
+  WARNING: Forced re-initialization is inherently unsafe if other modules are using the node ID.
 
   The function returns a pointer to an internal static buffer that remains valid for the lifetime
   of the process. The string is null-terminated.
@@ -15,7 +25,6 @@ description: |
 license: ISC
 
 dependencies:
-  # Require ESP-IDF version that provides esp_crc32_le and MAC helpers
   idf: ">=5.0"
 
 examples:

--- a/include/node_id.h
+++ b/include/node_id.h
@@ -2,14 +2,56 @@
 #define NODE_ID_H
 
 #include <stddef.h>
+#include <stdint.h>
+
+#ifdef PLATFORM_ESP
 #include "esp_err.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+#define ERROR_TYPE esp_err_t
+#define ERROR_OK ESP_OK
+#define ERROR_INVALID_ARG ESP_ERR_INVALID_ARG
+#define ERROR_NO_MEM ESP_ERR_NO_MEM
+#define ERROR ESP_FAIL
+#endif
+
+#ifndef ERROR_TYPE
+#define ERROR_TYPE uint32_t
+#define ERROR_OK 0
+#define ERROR_INVALID_ARG 1
+#define ERROR_NO_MEM 2
+#define ERROR_FAIL 3
+#endif
+
+#define NODE_ID_MAX_LEN 20 // Format: "XXXXX-XXXXX-XXX-C", where
+                           // 5 digits + 1 dash + 5 digits + 1 dash + 3 digits + 1 dash + 1 check char + 1 null terminator
+                           // = 5 + 1 + 5 + 1 + 3 + 1 + 1 + 1 = 18 (actual string) + 1 (check char) + 1 (null terminator) = 20
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-    esp_err_t get_node_id(char **node_id, size_t *len);
+    /**
+     * Initialize the node ID (thread-safe).
+     * If identity_str is NULL, falls back to MAC address.
+     * Returns pointer to static buffer, never freed.
+     */
+    ERROR_TYPE node_id_init(const uint8_t *identity_str, size_t len);
+
+    /**
+     * Force re-initialization of the node ID (thread-safe, but unsafe for consumers holding pointer).
+     * Overwrites static buffer if identity changes. Use with caution.
+     */
+    ERROR_TYPE node_id_force_init(const uint8_t *identity_str, size_t len);
+
+    /**
+     * Get the current node ID string and its length.
+     * The returned pointer is to a static buffer valid for the process lifetime.
+     */
+    ERROR_TYPE get_node_id(char **node_id, size_t *len);
 
 #ifdef __cplusplus
 }

--- a/node_id.c
+++ b/node_id.c
@@ -1,126 +1,245 @@
-// Public header for this component
 #include "node_id.h"
 
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
-
-#include "esp_crc.h"
-#include "esp_mac.h"
-
-/**
- * Node ID format and buffer sizing.
- *
- * Final string shape: "XXXX-XXXC" (9 visible chars + null terminator)
- * - 7 chars are Base32 (Crockford) encoding of a CRC32 over the factory MAC
- * - The last char is a 5-bit checksum derived from those 7 chars
- */
-#define NODE_ID_PAYLOAD_LEN 7
-#define NODE_ID_STR_LEN 9
-#define NODE_ID_BUF_LEN (NODE_ID_STR_LEN + 1)
+#include <stddef.h>
+#include <stdlib.h>
 
 // Base32 Crockford alphabet (no I, L, O, U)
-static const char s_crock32[] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+static const char *B32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
-// Compile-time sanity: ensure alphabet has 32 symbols
-_Static_assert(sizeof(s_crock32) - 1 == 32, "Crockford alphabet must have 32 symbols");
+static const char *NODE_ID_NAMESPACE = "PH_NODE_ID"; // Photon Circus Node ID namespace to prevent collision
 
 // Base32 Crockford encoded node ID with checksum: "XXXX-XXXC"
-static char s_node_id[NODE_ID_BUF_LEN] = {0};
+static char s_node_id[NODE_ID_MAX_LEN] = {0};
 static bool s_node_id_initialized = false;
 
-// Map 5-bit value to Crockford char
-static inline char crock32_encode5(uint8_t v)
-{
-    return s_crock32[v & 0x1F];
-}
+#define NODE_MAC_ADDR_STRLEN 18
 
-// Encode 32-bit value into exactly 7 Crockford chars (MSB zero-padded)
-static void crock32_encode_u32_7(uint32_t x, char out[NODE_ID_PAYLOAD_LEN])
+#ifdef ESP_PLATFORM
+
+#include "esp_log.h"
+#include "esp_mac.h"
+#include "mbedtls/sha256.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+static SemaphoreHandle_t s_node_id_mutex = NULL;
+
+static ERROR_TYPE hash_sha256(const uint8_t *data, size_t len, uint8_t *out, size_t *out_len)
 {
-    // 7 chars * 5 bits = 35 bits (but we only have 32; top 3 bits are zero)
-    for (int i = NODE_ID_PAYLOAD_LEN - 1; i >= 0; --i)
+    if (!data || !out || !out_len)
     {
-        out[i] = crock32_encode5((uint8_t)(x & 0x1F));
-        x >>= 5;
+        return ERROR_INVALID_ARG;
     }
-}
-
-// CRC-8 (poly 0x31, init 0xFF) over payload chars, folded to 5 bits (1 symbol)
-static uint8_t checksum5_over_payload(const char *data, size_t len)
-{
-    uint8_t crc = 0xFF;
-    for (size_t i = 0; i < len; ++i)
+    if (*out_len < 32)
     {
-        crc ^= (uint8_t)data[i];
-        for (int b = 0; b < 8; ++b)
-        {
-            crc = (crc & 0x80) ? (uint8_t)((crc << 1) ^ 0x31) : (uint8_t)(crc << 1);
-        }
-    }
-    // Fold to 5 bits; ensure non-zero to avoid visually empty checksum
-    uint8_t folded = (uint8_t)((crc ^ (crc >> 5) ^ (crc >> 3)) & 0x1F);
-    return (folded == 0) ? 1 : folded;
-}
-
-// Build the cached node ID string once
-static esp_err_t node_id_make(void)
-{
-    if (s_node_id_initialized)
-    {
-        return ESP_OK;
+        return ERROR_INVALID_ARG;
     }
 
-    // Read factory MAC (48-bit)
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts(&ctx, 0);
+    mbedtls_sha256_update(&ctx, data, len);
+    mbedtls_sha256_finish(&ctx, out);
+    mbedtls_sha256_free(&ctx);
+
+    return ERROR_OK;
+}
+
+static ERROR_TYPE get_node_mac(char *out)
+{
     uint8_t mac[6] = {0};
-    esp_efuse_mac_get_default(mac);
+    if (esp_efuse_mac_get_default(mac) != ESP_OK)
+    {
+        return ERROR_FAIL;
+    }
+    snprintf(out, NODE_MAC_ADDR_STRLEN, "%02X:%02X:%02X:%02X:%02X:%02X",
+             mac[0], mac[1], mac[2],
+             mac[3], mac[4], mac[5]);
+    return ERROR_OK;
+}
 
-    // CRC-32 over 6 bytes (IDF uses little-endian variant)
-    uint32_t crc = 0xFFFFFFFFu;
-    crc = esp_crc32_le(crc, mac, sizeof(mac));
-    crc ^= 0xFFFFFFFFu;
+#else
+#error Only esp_idf supported
+#endif
 
-    // Encode 32-bit → 7 Crockford chars (not null-terminated)
-    char payload[NODE_ID_PAYLOAD_LEN];
-    crock32_encode_u32_7(crc, payload);
+static uint8_t mod37_check(const uint8_t *bytes, size_t len)
+{
+    // Simple mod-37 checksum over the underlying hash bytes (maps to 0..36)
+    uint32_t s = 0;
+    for (size_t i = 0; i < len; i++)
+        s = (s + bytes[i]) % 37;
+    return (uint8_t)s;
+}
 
-    // Compute 1-char checksum from payload
-    const uint8_t check5 = checksum5_over_payload(payload, NODE_ID_PAYLOAD_LEN);
-    const char check_ch = crock32_encode5(check5);
+static void b32_64bits_to_13(const uint8_t h[8], char out[14])
+{
+    // 64 bits -> 13 symbols (since 13*5 = 65 >= 64)
+    uint64_t v = ((uint64_t)h[0] << 56) | ((uint64_t)h[1] << 48) | ((uint64_t)h[2] << 40) | ((uint64_t)h[3] << 32) |
+                 ((uint64_t)h[4] << 24) | ((uint64_t)h[5] << 16) | ((uint64_t)h[6] << 8) | ((uint64_t)h[7]);
+    for (int i = 12; i >= 0; i--)
+    {
+        out[i] = B32[v & 0x1F];
+        v >>= 5;
+    }
+    out[13] = '\0';
+}
 
-    // Assemble final string: AAAA-BBBC
-    memcpy(&s_node_id[0], &payload[0], 4);
-    s_node_id[4] = '-';
-    memcpy(&s_node_id[5], &payload[4], 3);
-    s_node_id[8] = check_ch;
-    s_node_id[9] = '\0';
+static void apply_format_and_store(const char core13[14], uint8_t check)
+{
+    // "XXXXX-XXXXX-XXX" + "-" + check char => up to 18-19 chars
+    // group 5-5-3 for readability
+    char grouped[18] = {0};
+    memcpy(&grouped[0], &core13[0], 5);
+    grouped[5] = '-';
+    memcpy(&grouped[6], &core13[5], 5);
+    grouped[11] = '-';
+    memcpy(&grouped[12], &core13[10], 3);
+    grouped[15] = '-';
+    grouped[16] = B32[check % 32];
+    grouped[17] = '\0';
+    strncpy(s_node_id, grouped, NODE_ID_MAX_LEN);
+}
+
+static ERROR_TYPE make_id(const uint8_t *identity_str, size_t len)
+{
+    char *buffer = (char *)malloc(len + strlen(NODE_ID_NAMESPACE));
+    if (!buffer)
+        return ERROR_NO_MEM;
+
+    memcpy(buffer, NODE_ID_NAMESPACE, strlen(NODE_ID_NAMESPACE));
+    memcpy(buffer + strlen(NODE_ID_NAMESPACE), identity_str, len);
+
+    uint8_t hash[32] = {0};
+    size_t hash_len = 32;
+    if (hash_sha256((const uint8_t *)buffer, len + strlen(NODE_ID_NAMESPACE), hash, &hash_len) != ERROR_OK)
+    {
+        free(buffer);
+        return ERROR_NO_MEM;
+    }
+    free(buffer);
+
+    char core13[14];
+    b32_64bits_to_13(hash, core13);
+    uint8_t chk = mod37_check(hash, 8);
+
+    apply_format_and_store(core13, chk);
+
+    return ERROR_OK;
+}
+
+
+// Internal helper: assumes mutex is held
+static ERROR_TYPE node_id_init_locked(const uint8_t *identity_str, size_t len, bool force)
+{
+    if (!identity_str)
+    {
+        char mac_str[NODE_MAC_ADDR_STRLEN] = {0};
+        if (get_node_mac(mac_str) != ERROR_OK)
+        {
+            return ERROR_FAIL;
+        }
+        identity_str = (uint8_t *)mac_str;
+        len = strlen(mac_str);
+    }
+
+    if (s_node_id_initialized && !force)
+        return ERROR_OK;
+
+    if (make_id(identity_str, len) != ERROR_OK)
+    {
+        return ERROR_FAIL;
+    }
 
     s_node_id_initialized = true;
-    return ESP_OK;
+    return ERROR_OK;
 }
 
-/**
- * Retrieve the unique node ID string.
- *
- * Outputs a pointer to a static, null-terminated buffer that remains valid for the
- * duration of the program. Thread-safety: initialization is not guarded; if multiple
- * tasks call this simultaneously on the first use, they may race during construction,
- * but the final value will be consistent thereafter.
- */
-esp_err_t get_node_id(char **node_id, size_t *len)
+ERROR_TYPE node_id_init(const uint8_t *identity_str, size_t len)
+{
+    // Initialize mutex once
+    if (s_node_id_mutex == NULL)
+    {
+        SemaphoreHandle_t m = xSemaphoreCreateMutex();
+        if (m == NULL)
+        {
+            return ERROR_NO_MEM;
+        }
+        if (s_node_id_mutex == NULL)
+            s_node_id_mutex = m;
+        else
+            vSemaphoreDelete(m);
+    }
+
+    if (xSemaphoreTake(s_node_id_mutex, portMAX_DELAY) != pdTRUE)
+        return ERROR_FAIL;
+
+    ERROR_TYPE result = node_id_init_locked(identity_str, len, false);
+    xSemaphoreGive(s_node_id_mutex);
+    return result;
+}
+
+ERROR_TYPE node_id_force_init(const uint8_t *identity_str, size_t len)
+{
+    if (!identity_str || len == 0)
+        return ERROR_INVALID_ARG;
+
+    if (s_node_id_mutex == NULL)
+    {
+        SemaphoreHandle_t m = xSemaphoreCreateMutex();
+        if (m == NULL)
+            return ERROR_NO_MEM;
+        if (s_node_id_mutex == NULL)
+            s_node_id_mutex = m;
+        else
+            vSemaphoreDelete(m);
+    }
+
+    if (xSemaphoreTake(s_node_id_mutex, portMAX_DELAY) != pdTRUE)
+        return ERROR_FAIL;
+
+    // Warn about buffer overwrite
+    #ifdef ESP_PLATFORM
+    ESP_LOGW("node_id", "node_id_force_init: Overwriting static node ID buffer. Unsafe if other modules hold pointer.");
+    #endif
+
+    // Save previous ID
+    char prev_id[NODE_ID_MAX_LEN];
+    strncpy(prev_id, s_node_id, NODE_ID_MAX_LEN);
+    prev_id[NODE_ID_MAX_LEN - 1] = '\0';
+
+    ERROR_TYPE result = node_id_init_locked(identity_str, len, true);
+
+    // If new ID is different, log warning
+    if (strncmp(prev_id, s_node_id, NODE_ID_MAX_LEN) != 0) {
+        #ifdef ESP_PLATFORM
+        ESP_LOGW("node_id", "node_id_force_init: Node ID buffer changed from '%s' to '%s'", prev_id, s_node_id);
+        #endif
+    }
+
+    xSemaphoreGive(s_node_id_mutex);
+    return result;
+}
+
+ERROR_TYPE get_node_id(char **node_id, size_t *len)
 {
     if (!node_id || !len)
     {
-        return ESP_ERR_INVALID_ARG;
+        return ERROR_INVALID_ARG;
     }
 
-    esp_err_t err = node_id_make();
-    if (err != ESP_OK)
+    if (!s_node_id_initialized)
     {
-        return err;
+        if (node_id_init(NULL, 0) != ERROR_OK)
+        {
+            return ERROR_FAIL;
+        }
     }
 
     *node_id = s_node_id;
     *len = strlen(s_node_id);
-    return ESP_OK;
+    return ERROR_OK;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "test_node_id.c"
+    INCLUDE_DIRS ".."
+    REQUIRES unity
+)

--- a/test/test_node_id.c
+++ b/test/test_node_id.c
@@ -1,0 +1,86 @@
+
+#include <stdio.h>
+#include <string.h>
+#include "unity.h"
+#include "node_id.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+// Unity setup/teardown
+void setUp(void) {}
+void tearDown(void) {}
+
+// Test: Default node ID (MAC-based)
+void test_default_node_id(void)
+{
+    char *id = NULL;
+    size_t len = 0;
+    TEST_ASSERT_EQUAL(ERROR_OK, get_node_id(&id, &len));
+    TEST_ASSERT_NOT_NULL(id);
+    TEST_ASSERT_TRUE(len > 0);
+    TEST_ASSERT_TRUE(strlen(id) == len);
+}
+
+// Test: Custom identity
+void test_custom_identity(void)
+{
+    const uint8_t custom_id[] = "TEST_CUSTOM_IDENTITY";
+    TEST_ASSERT_EQUAL(ERROR_OK, node_id_force_init(custom_id, sizeof(custom_id) - 1));
+    char *id = NULL;
+    size_t len = 0;
+    TEST_ASSERT_EQUAL(ERROR_OK, get_node_id(&id, &len));
+    TEST_ASSERT_NOT_NULL(id);
+    // Node ID should change after force init
+}
+
+// Thread safety helpers
+static void thread_init_task(void *param)
+{
+    const uint8_t *identity = (const uint8_t *)param;
+    for (int i = 0; i < 10; ++i)
+    {
+        TEST_ASSERT_EQUAL(ERROR_OK, node_id_init(identity, strlen((const char *)identity)));
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    vTaskDelete(NULL);
+}
+
+static void thread_get_task(void *param)
+{
+    for (int i = 0; i < 10; ++i)
+    {
+        char *id = NULL;
+        size_t len = 0;
+        TEST_ASSERT_EQUAL(ERROR_OK, get_node_id(&id, &len));
+        TEST_ASSERT_NOT_NULL(id);
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    vTaskDelete(NULL);
+}
+
+// Test: Thread safety
+void test_thread_safety(void)
+{
+    const uint8_t id1[] = "THREAD_ID1";
+    const uint8_t id2[] = "THREAD_ID2";
+    xTaskCreate(thread_init_task, "init_task1", 2048, (void *)id1, 5, NULL);
+    xTaskCreate(thread_init_task, "init_task2", 2048, (void *)id2, 5, NULL);
+    xTaskCreate(thread_get_task, "get_task1", 2048, NULL, 5, NULL);
+    xTaskCreate(thread_get_task, "get_task2", 2048, NULL, 5, NULL);
+    vTaskDelay(pdMS_TO_TICKS(300));
+}
+
+// Unity test cases
+TEST_CASE("Default node ID", "[node_id]") { test_default_node_id(); }
+TEST_CASE("Custom identity", "[node_id]") { test_custom_identity(); }
+TEST_CASE("Thread safety", "[node_id]") { test_thread_safety(); }
+
+// Main entry
+int app_main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_default_node_id);
+    RUN_TEST(test_custom_identity);
+    RUN_TEST(test_thread_safety);
+    return UNITY_END();
+}


### PR DESCRIPTION
…tity support

- Implemented thread-safe initialization of node ID using FreeRTOS mutex.
- Added support for custom identity input to node_id_init.
- Introduced node_id_force_init API for forced re-initialization.
- Updated documentation and examples to reflect new features.
- Added unit tests for default node ID, custom identity, and thread safety.
- Created .gitignore and CHANGELOG files for better project management.